### PR TITLE
Update dankify.js

### DIFF
--- a/dankify.js
+++ b/dankify.js
@@ -1,4 +1,4 @@
-$('*')
+$('*:not(iframe)')
   .contents()
   .filter(function() {
     return this.nodeType === 3; 


### PR DESCRIPTION
iframe elements throwing the following error:

Uncaught DOMException: Failed to read the 'contentDocument' property from 'HTMLIFrameElement': Blocked a frame with origin "http://....." from accessing a cross-origin frame.
